### PR TITLE
Upgrade Ruby and switch to Standard Ruby

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,17 +24,17 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
-      
+
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.3
+          ruby-version: 3.3
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
       - name: Run linting and unit tests
         run: |
           gem install bundler
           bundle install --jobs 4 --retry 3
-          bundle exec rubocop -c .rubocop.yml
+          bundle exec standardrb
           bundle exec rake test
 
       - name: Validate the glossary

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-ruby '~> 2.7'
+ruby "~> 3"
 
-gem 'minitest-reporters'
-gem 'rake'
-gem 'rubocop', '~> 1.25', require: false
+gem "minitest-reporters"
+gem "rake"
+gem "standard"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,33 +3,57 @@ GEM
   specs:
     ansi (1.5.0)
     ast (2.4.2)
-    builder (3.2.4)
-    minitest (5.15.0)
-    minitest-reporters (1.5.0)
+    builder (3.3.0)
+    json (2.7.2)
+    language_server-protocol (3.17.0.3)
+    lint_roller (1.1.0)
+    minitest (5.23.1)
+    minitest-reporters (1.6.1)
       ansi
       builder
       minitest (>= 5.0)
       ruby-progressbar
-    parallel (1.21.0)
-    parser (3.1.0.0)
+    parallel (1.24.0)
+    parser (3.3.2.0)
       ast (~> 2.4.1)
+      racc
+    racc (1.8.0)
     rainbow (3.1.1)
-    rake (13.0.6)
-    regexp_parser (2.2.0)
-    rexml (3.2.5)
-    rubocop (1.25.1)
+    rake (13.2.1)
+    regexp_parser (2.9.2)
+    rexml (3.2.8)
+      strscan (>= 3.0.9)
+    rubocop (1.63.5)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.1.0.0)
+      parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
-      rexml
-      rubocop-ast (>= 1.15.1, < 2.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.15.1)
-      parser (>= 3.0.1.1)
-    ruby-progressbar (1.11.0)
-    unicode-display_width (2.1.0)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.31.3)
+      parser (>= 3.3.1.0)
+    rubocop-performance (1.21.0)
+      rubocop (>= 1.48.1, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+    ruby-progressbar (1.13.0)
+    standard (1.36.0)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.63.0)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.4)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.4.0)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.21.0)
+    strscan (3.1.0)
+    unicode-display_width (2.5.0)
 
 PLATFORMS
   ruby
@@ -37,10 +61,10 @@ PLATFORMS
 DEPENDENCIES
   minitest-reporters
   rake
-  rubocop (~> 1.25)
+  standard
 
 RUBY VERSION
-   ruby 2.7.3p183
+   ruby 3.2.3p157
 
 BUNDLED WITH
    2.1.4

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
 task default: :test
 task :test do
-  Dir.glob('./test/*_test.rb').each { |file| require file }
+  Dir.glob("./test/*_test.rb").each { |file| require file }
 end

--- a/lib/markdownify.rb
+++ b/lib/markdownify.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 # Thanks https://avdi.codes/recursively-symbolize-keys/
-require 'yaml'
-require './lib/common'
-require './lib/validate'
+require "yaml"
+require "./lib/common"
+require "./lib/validate"
 
 # Turn a validated glossary into a linked Markdown file
 class Markdownify
@@ -12,23 +12,23 @@ class Markdownify
   attr_reader :data, :path, :output
 
   def initialize(path = nil, outpath = nil)
-    @path = path || './glossary.yml'
-    @output = outpath || './glossary.md'
+    @path = path || "./glossary.yml"
+    @output = outpath || "./glossary.md"
     @data = sort_data(
       symbolize_keys(
-        YAML.load_file(@path)
+        YAML.load_file(@path, aliases: true)
       )
     )
   end
 
   def perform
-    File.open(output, 'w') { |file| file << _perform }
+    File.open(output, "w") { |file| file << _perform }
     puts "\nSuccess! Check out your file at #{output}"
   end
 
   def _perform
     before_perform
-    str = ''
+    str = ""
     str += "### Acronyms & Initialisms\n\n"
     str += acronym_content
     str += "\n\n"
@@ -38,11 +38,11 @@ class Markdownify
   end
 
   def acronym_content
-    str = ''
+    str = ""
     str += "| | |\n|-|-|\n" # table header
     build_tags_by_letter.sort.map do |letter, tags|
       str += "| #{letter} | "
-      str += "#{tags.join(' &bull; ')} |"
+      str += "#{tags.join(" &bull; ")} |"
       str += "\n"
     end
     str
@@ -54,13 +54,13 @@ class Markdownify
       tag = tag_for_acronym(key, values)
       next if tag.nil?
 
-      results[key.to_s.chars.first.upcase] << tag
+      results[key.to_s[0].upcase] << tag
     end
     results
   end
 
   def tag_for_acronym(key, values)
-    case Array(values[:term]).count
+    case Array(values[:term]).size
     when 0
       nil
     when 1
@@ -79,7 +79,7 @@ class Markdownify
   def tag_for_multiple_terms(key, values)
     term_links = values[:term].map.with_index do |term, i|
       "[(#{i + 1})](#{goto term})"
-    end.join(' ')
+    end.join(" ")
     <<~TAG
       <a name="acronym-#{key}"></a>#{key} #{term_links}
     TAG
@@ -92,7 +92,7 @@ class Markdownify
   end
 
   def build_definition(key, values)
-    str = ''
+    str = ""
     str += "**#{anchor(key)}#{self_link(key)}**"
     str += (acronym?(key) ? " (#{acronym_for(key).first}) \\\n" : " \\\n")
     str += description_content(values)
@@ -117,7 +117,7 @@ class Markdownify
   def overloaded_acronym?(key)
     if acronym?(key)
       _, values = acronym_for(key)
-      Array(values[:term]).count > 1
+      Array(values[:term]).size > 1
     else
       false
     end
@@ -178,7 +178,7 @@ class Markdownify
   end
 
   def slug(key)
-    key.to_s.downcase.gsub(/\s+/, '-')
+    key.to_s.downcase.gsub(/\s+/, "-")
   end
 
   private
@@ -193,12 +193,12 @@ class Markdownify
     data[:entries].each do |entry|
       key, values = entry
       case values[:type]
-      when 'acronym'
+      when "acronym"
         acronyms[key] = values
-      when 'term'
+      when "term"
         terms[key] = values
       end
     end
-    { acronyms: acronyms, terms: terms }
+    {acronyms: acronyms, terms: terms}
   end
 end

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -8,60 +8,48 @@ module Fixtures
   # ACRONYMS : VALID
 
   def valid_acronym
-    { FIDO:
-      { type: 'acronym',
-        term: 'Federal Interagency Databases Online'
-      }
-    }
+    {FIDO:
+      {type: "acronym",
+       term: "Federal Interagency Databases Online"}}
   end
 
   def valid_acronym_multi
-    { POP:
-      { type: 'acronym',
-        term:
-        ['Period of performance',
-         'Procurement Operating Procedure']
-      }
-    }
+    {POP:
+      {type: "acronym",
+       term:
+        ["Period of performance",
+          "Procurement Operating Procedure"]}}
   end
 
   # ACRONYMS : INVALID
 
   def invalid_acronym_no_type
-    { FIDO:
-      { term: 'Federal Interagency Databases Online' }
-    }
+    {FIDO:
+      {term: "Federal Interagency Databases Online"}}
   end
 
   def invalid_acronym_no_term
-    { FIDO:
-      { type: 'acronym' }
-    }
+    {FIDO:
+      {type: "acronym"}}
   end
 
   def invalid_acronym_null_term
-    { FIDO:
-      { type: 'acronym',
-        term: nil
-      }
-    }
+    {FIDO:
+      {type: "acronym",
+       term: nil}}
   end
 
   def invalid_acronym_extra_keys
-    { FIDO:
-      { type: 'acronym',
-        term: 'Federal Interagency Databases Online',
-        longform: 'hey'
-      }
-    }
+    {FIDO:
+      {type: "acronym",
+       term: "Federal Interagency Databases Online",
+       longform: "hey"}}
   end
 
   def invalid_acronym_refers_to_acronym
-    { FIDO:
-      { type: 'acronym',
-        term: 'ODIF'
-      }
-    }
+    {FIDO:
+      {type: "acronym",
+       term: "ODIF"}}
   end
 
   #
@@ -71,57 +59,47 @@ module Fixtures
   # TERMS : VALID
 
   def valid_term
-    { "Federal Interagency Databases Online":
-      { type: 'term',
-        description: 'Fido.gov is an internet location for finding information related to federal interagency databases.',
-        longform: 'An even more expanded version of the term.'
-      }
-    }
+    {"Federal Interagency Databases Online":
+      {type: "term",
+       description: "Fido.gov is an internet location for finding information related to federal interagency databases.",
+       longform: "An even more expanded version of the term."}}
   end
 
   def valid_term_null_desc
-    { "Federal Interagency Databases Online":
-      { type: 'term',
-        description: nil
-      }
-    }
+    {"Federal Interagency Databases Online":
+      {type: "term",
+       description: nil}}
   end
 
   def valid_term_pop1
     {
       "Period of performance":
-        { type: 'term',
-          description: 'Description for period of performance'
-        }
+        {type: "term",
+         description: "Description for period of performance"}
     }
   end
 
   def valid_term_pop2
     {
       "Procurement Operating Procedure":
-        { type: 'term',
-          description: 'Description for procurement operating procedure'
-        }
+        {type: "term",
+         description: "Description for procurement operating procedure"}
     }
   end
 
   def valid_term_no_crossref
-    { "Federal Interagency Databases Online":
-      { type: 'term',
-        description: 'Fido.gov is an internet location for finding information related to federal interagency databases.'
-      }
-    }
+    {"Federal Interagency Databases Online":
+      {type: "term",
+       description: "Fido.gov is an internet location for finding information related to federal interagency databases."}}
   end
 
   def valid_term_matching_crossrefs
-    { "Federal Interagency Databases Online":
-      { type: 'term',
-        description: 'Fido.gov is an internet location for finding information related to federal interagency databases.',
-        cross_references:
-        ['Period of performance',
-         'Procurement Operating Procedure']
-      }
-    }
+    {"Federal Interagency Databases Online":
+      {type: "term",
+       description: "Fido.gov is an internet location for finding information related to federal interagency databases.",
+       cross_references:
+        ["Period of performance",
+          "Procurement Operating Procedure"]}}
   end
 
   # TERMS : INVALID
@@ -131,43 +109,36 @@ module Fixtures
   end
 
   def invalid_term_no_desc
-    { "Federal Interagency Databases Online":
-      { type: 'term' }
-    }
+    {"Federal Interagency Databases Online":
+      {type: "term"}}
   end
 
   def invalid_term_mismatched_crossrefs
-    { "Federal Interagency Databases Online":
-      { type: 'term',
-        description: 'Fido.gov is an internet location for finding information related to federal interagency databases.',
-        cross_references:
+    {"Federal Interagency Databases Online":
+      {type: "term",
+       description: "Fido.gov is an internet location for finding information related to federal interagency databases.",
+       cross_references:
         [
-          'Period of performance',
-          'Not a match'
-        ]
-      }
-    }
+          "Period of performance",
+          "Not a match"
+        ]}}
   end
 
   def invalid_term_crossrefs_acronym
-    { "A term in the glossary":
-      { type: 'term',
-        description: "This is a term that appears in the glossary and its description written here so people know it's just a term.",
-        cross_references:
+    {"A term in the glossary":
+      {type: "term",
+       description: "This is a term that appears in the glossary and its description written here so people know it's just a term.",
+       cross_references:
         [
-          'ACRO'
-        ]
-      }
-    }
+          "ACRO"
+        ]}}
   end
 
   def invalid_term_extra_keys
-    { "Federal Interagency Databases Online":
-      { type: 'term',
-        description: 'Fido.gov is an internet location for finding information related to federal interagency databases.',
-        has_extra_key: 'Yes'
-      }
-    }
+    {"Federal Interagency Databases Online":
+      {type: "term",
+       description: "Fido.gov is an internet location for finding information related to federal interagency databases.",
+       has_extra_key: "Yes"}}
   end
 
   #
@@ -191,18 +162,14 @@ module Fixtures
   end
 
   def context_for_invalid_acronym_refers_to_acronym
-    { ODIF:
-      { type: 'acronym',
-        term: 'Online Database of Interagency Federation'
-      }
-    }
+    {ODIF:
+      {type: "acronym",
+       term: "Online Database of Interagency Federation"}}
   end
 
   def context_term_cross_references_acronym
-    { ACRO:
-      { type: 'acronym',
-        term: 'Letters That Stand For Words'
-      }
-    }
+    {ACRO:
+      {type: "acronym",
+       term: "Letters That Stand For Words"}}
   end
 end

--- a/test/markdownify_test.rb
+++ b/test/markdownify_test.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require './test/test_helper'
-require './lib/markdownify'
+require "./test/test_helper"
+require "./lib/markdownify"
 
 describe Markdownify do
-  describe 'with a valid glossary.yml' do
-    it 'renders markdown' do
-      subject = Markdownify.new('./test/test_glossary.yml')
+  describe "with a valid glossary.yml" do
+    it "renders markdown" do
+      subject = Markdownify.new("./test/test_glossary.yml")
       assert_equal valid_markdown, subject._perform, highlight: true
     end
   end
@@ -18,16 +18,16 @@ def valid_markdown
 
     | | |
     |-|-|
-    | F | <a name=\"acronym-FEMA\"></a>[FEMA](#federal-emergency-management-agency) &bull; <a name=\"acronym-FIDO\"></a>[FIDO](#federal-interagency-databases-online) |
-    | P | <a name=\"acronym-POP\"></a>POP [(1)](#period-of-performance) [(2)](#procurement-operating-procedure) |
+    | F | <a name="acronym-FEMA"></a>[FEMA](#federal-emergency-management-agency) &bull; <a name="acronym-FIDO"></a>[FIDO](#federal-interagency-databases-online) |
+    | P | <a name="acronym-POP"></a>POP [(1)](#period-of-performance) [(2)](#procurement-operating-procedure) |
 
 
     ### Terms & Definitions
 
-    **<a name=\"federal-emergency-management-agency\"></a>[Federal Emergency Management Agency](#federal-emergency-management-agency)** (FEMA) \\
+    **<a name="federal-emergency-management-agency"></a>[Federal Emergency Management Agency](#federal-emergency-management-agency)** (FEMA) \\
     _No definition provided._
 
-    **<a name=\"federal-interagency-databases-online\"></a>[Federal Interagency Databases Online](#federal-interagency-databases-online)** (FIDO) \\
+    **<a name="federal-interagency-databases-online"></a>[Federal Interagency Databases Online](#federal-interagency-databases-online)** (FIDO) \\
     Fido.gov is an internet location for finding information related to federal interagency databases.
 
     Cross-references:
@@ -35,12 +35,12 @@ def valid_markdown
       - [Period of performance](#period-of-performance)
       - [Procurement Operating Procedure](#procurement-operating-procedure)
 
-    **<a name=\"period-of-performance\"></a>[Period of performance](#period-of-performance)** (POP) \\
+    **<a name="period-of-performance"></a>[Period of performance](#period-of-performance)** (POP) \\
     Description for period of performance
 
     _Not the definition you were looking for?_ [Back to POP](#acronym-POP)
 
-    **<a name=\"procurement-operating-procedure\"></a>[Procurement Operating Procedure](#procurement-operating-procedure)** (POP) \\
+    **<a name="procurement-operating-procedure"></a>[Procurement Operating Procedure](#procurement-operating-procedure)** (POP) \\
     Description for procurement operating procedure
 
     _Not the definition you were looking for?_ [Back to POP](#acronym-POP)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
-require 'minitest/reporters'
+require "minitest/autorun"
+require "minitest/reporters"
 Minitest::Reporters.use!

--- a/test/validate_test.rb
+++ b/test/validate_test.rb
@@ -1,130 +1,131 @@
 # frozen_string_literal: true
 
-require './test/test_helper'
-require './lib/validate'
-require './test/fixtures'
-
-include Fixtures
+require "./test/test_helper"
+require "./lib/validate"
+require "./test/fixtures"
 
 describe GlossaryValidator do
-  describe 'with a valid glossary' do
-    it 'raises no errors' do
-      subject = GlossaryValidator.new(path: './test/test_glossary.yml')
+  include Fixtures
+
+  describe "with a valid glossary" do
+    it "raises no errors" do
+      subject = GlossaryValidator.new(path: "./test/test_glossary.yml")
       assert subject.perform
     end
   end
 
-  describe 'with a glossary containing duplicate entries' do
-    it 'raises an error' do
-      subject = GlossaryValidator.new(path: './test/test_glossary_dupe.yml')
+  describe "with a glossary containing duplicate entries" do
+    it "raises an error" do
+      subject = GlossaryValidator.new(path: "./test/test_glossary_dupe.yml")
       assert_raises(DuplicateKeyError) { subject.perform }
     end
   end
 end
 
 describe EntryValidator do
-  describe 'with a malformed entry' do
-    it 'errors' do
+  include Fixtures
+  describe "with a malformed entry" do
+    it "errors" do
       subject = EntryValidator.new({})
-      assert_raises(ArgumentError) { subject.validate({ a: 1, b: 2 }) }
+      assert_raises(ArgumentError) { subject.validate({a: 1, b: 2}) }
     end
   end
 
-  describe 'term' do
-    describe 'with a valid term' do
-      it 'is valid' do
+  describe "term" do
+    describe "with a valid term" do
+      it "is valid" do
         subject = EntryValidator.new({})
         assert_equal true, subject.validate(valid_term)
       end
     end
-    describe 'without a description' do
-      it 'is invalid' do
+    describe "without a description" do
+      it "is invalid" do
         subject = EntryValidator.new({})
         assert_raises(TermMissingDescriptionError) { subject.validate(invalid_term_no_desc) }
       end
     end
-    describe 'with extra keys' do
-      it 'is invalid' do
+    describe "with extra keys" do
+      it "is invalid" do
         subject = EntryValidator.new({})
         assert_raises(BadSchemaError) { subject.validate(invalid_term_extra_keys) }
       end
     end
-    describe 'without cross-references' do
-      it 'is valid' do
+    describe "without cross-references" do
+      it "is valid" do
         subject = EntryValidator.new({})
         assert_equal true, subject.validate(valid_term_no_crossref)
       end
     end
-    describe 'with cross-references' do
-      describe 'that all match' do
-        it 'is valid' do
+    describe "with cross-references" do
+      describe "that all match" do
+        it "is valid" do
           subject = EntryValidator.new(context_matching_crossrefs)
           assert_equal true, subject.validate(valid_term_matching_crossrefs)
         end
       end
       describe "that don't match" do
-        it 'is invalid' do
+        it "is invalid" do
           subject = EntryValidator.new(context_matching_crossrefs)
           assert_raises(TermNotFoundError) { subject.validate(invalid_term_mismatched_crossrefs) }
         end
       end
-      describe 'to a valid acronym' do
-        it 'is invalid' do
+      describe "to a valid acronym" do
+        it "is invalid" do
           subject = EntryValidator.new(context_term_cross_references_acronym)
           assert_raises(CrossreferencesAcronymError) { subject.validate(invalid_term_crossrefs_acronym) }
         end
       end
     end
-    describe 'with an explicitly null description' do
-      it 'is valid' do
+    describe "with an explicitly null description" do
+      it "is valid" do
         subject = EntryValidator.new({})
         assert_equal true, subject.validate(valid_term_null_desc)
       end
     end
   end
 
-  describe 'acronym' do
-    describe 'without a type' do
-      it 'is invalid' do
+  describe "acronym" do
+    describe "without a type" do
+      it "is invalid" do
         subject = EntryValidator.new({})
         assert_raises(EntryTypeError) { subject.validate(invalid_acronym_no_type) }
       end
     end
-    describe 'without a term' do
-      it 'is invalid' do
+    describe "without a term" do
+      it "is invalid" do
         subject = EntryValidator.new({})
         assert_raises(MissingTermError) { subject.validate(invalid_acronym_no_term) }
       end
     end
-    describe 'with an explicitly null term' do
-      it 'is invalid' do
+    describe "with an explicitly null term" do
+      it "is invalid" do
         subject = EntryValidator.new({})
         assert_raises(MissingTermError) { subject.validate(invalid_acronym_null_term) }
       end
     end
-    describe 'with any other keys' do
-      it 'is invalid' do
+    describe "with any other keys" do
+      it "is invalid" do
         subject = EntryValidator.new(valid_term)
         assert_raises(BadSchemaError) { subject.validate(invalid_acronym_extra_keys) }
       end
     end
 
-    describe 'valid' do
-      describe 'referring to one term' do
-        describe 'matching a valid term' do
-          it 'is valid' do
+    describe "valid" do
+      describe "referring to one term" do
+        describe "matching a valid term" do
+          it "is valid" do
             subject = EntryValidator.new(context_for_valid_term)
             assert_equal true, subject.validate(valid_acronym)
           end
         end
-        describe 'matching an invalid term' do
-          it 'is valid' do
+        describe "matching an invalid term" do
+          it "is valid" do
             subject = EntryValidator.new(context_for_invalid_term)
             assert_equal true, subject.validate(valid_acronym)
           end
         end
-        describe 'that does not match' do
-          it 'is invalid' do
+        describe "that does not match" do
+          it "is invalid" do
             subject = EntryValidator.new({})
             assert_raises(TermNotFoundError) { subject.validate(valid_acronym) }
           end
@@ -132,22 +133,22 @@ describe EntryValidator do
       end
     end
 
-    describe 'referring to another acronym' do
-      it 'is invalid' do
+    describe "referring to another acronym" do
+      it "is invalid" do
         subject = EntryValidator.new(context_for_invalid_acronym_refers_to_acronym)
         assert_raises(AcronymReferenceError) { subject.validate(invalid_acronym_refers_to_acronym) }
       end
     end
 
-    describe 'referring to multiple terms' do
-      describe 'which all match' do
-        it 'is valid' do
+    describe "referring to multiple terms" do
+      describe "which all match" do
+        it "is valid" do
           subject = EntryValidator.new(context_for_valid_term_multi)
           assert_equal true, subject.validate(valid_acronym_multi)
         end
       end
       describe "one of which doesn't match a term" do
-        it 'is invalid' do
+        it "is invalid" do
           subject = EntryValidator.new(valid_term_pop1)
           assert_raises(TermNotFoundError) { subject.validate(valid_acronym_multi) }
         end


### PR DESCRIPTION
Ruby 2.7 was causing build issues, and is otherwise end-of-life.

- Upgrades to Ruby 3
- Updates YAML load messages for Ruby 3
- Switches from Rubocop to Standard Ruby, and fixes all Standard style violations